### PR TITLE
Add query string to validation

### DIFF
--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -79,9 +79,10 @@ func validateRequest(r *http.Request, router routers.Router, options *Options) (
 
 	// Validate request
 	requestValidationInput := &openapi3filter.RequestValidationInput{
-		Request:    r,
-		PathParams: pathParams,
-		Route:      route,
+		Request:     r,
+		PathParams:  pathParams,
+		QueryParams: r.URL.Query(),
+		Route:       route,
 	}
 
 	if options != nil {


### PR DESCRIPTION
This is a simple change which ensures the query string parameters are included in the validation.

As an example you may have a security scheme as follows, which was not being checked.

```
"components": {
    "securitySchemes": {
      "apiKey": {
        "type": "apiKey",
        "in": "query",
        "name": "apiKey"
      }
    }
}
```