### PR TITLE
Return http.StatusMethodNotAllowed for request method mismatch

### DIFF
--- a/internal/test/chi/oapi_validate_test.go
+++ b/internal/test/chi/oapi_validate_test.go
@@ -371,6 +371,19 @@ func testRequestValidatorBasicFunctions(t *testing.T, r *chi.Mux) {
 		called = false
 	}
 
+	// Send a request with wrong HTTP method
+	{
+		body := struct {
+			Name string `json:"name"`
+		}{
+			Name: "Marcin",
+		}
+		rec := doPost(t, r, "http://deepmap.ai/resource", body)
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
 	// Add a handler for the POST message
 	r.Post("/resource", func(w http.ResponseWriter, r *http.Request) {
 		called = true

--- a/internal/test/gorilla/oapi_validate_test.go
+++ b/internal/test/gorilla/oapi_validate_test.go
@@ -10,8 +10,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/oapi-codegen/testutil"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
+	"github.com/oapi-codegen/testutil"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -367,6 +367,19 @@ func testRequestValidatorBasicFunctions(t *testing.T, r *mux.Router) {
 	{
 		rec := doGet(t, r, "http://deepmap.ai/resource?id=foo")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
+	// Send a request with wrong HTTP method
+	{
+		body := struct {
+			Name string `json:"name"`
+		}{
+			Name: "Marcin",
+		}
+		rec := doPost(t, r, "http://deepmap.ai/resource", body)
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}

--- a/internal/test/gorilla/oapi_validate_test.go
+++ b/internal/test/gorilla/oapi_validate_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	middleware "github.com/oapi-codegen/nethttp-middleware"
-	"github.com/oapi-codegen/testutil"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"

--- a/internal/test/nethttp/oapi_validate_test.go
+++ b/internal/test/nethttp/oapi_validate_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	middleware "github.com/oapi-codegen/nethttp-middleware"
-	"github.com/oapi-codegen/testutil"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -69,8 +68,19 @@ func doPatch(t *testing.T, mux http.Handler, rawURL string, jsonBody interface{}
 		t.Fatalf("Invalid url: %s", rawURL)
 	}
 
-	response := testutil.NewRequest().Patch(u.RequestURI()).WithHost(u.Host).WithJsonBody(jsonBody).GoWithHTTPHandler(t, mux)
-	return response.Recorder
+	data, err := json.Marshal(jsonBody)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPatch, u.String(), bytes.NewReader(data))
+	require.NoError(t, err)
+
+	req.Header.Set("content-type", "application/json")
+
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	return rr
 }
 
 // use wraps a given http.ServeMux with middleware for execution

--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -90,6 +90,7 @@ func validateRequest(r *http.Request, router routers.Router, options *Options) (
 		if errors.Is(err, routers.ErrMethodNotAllowed) {
 			return http.StatusMethodNotAllowed, err
 		}
+
 		return http.StatusNotFound, err // We failed to find a matching route for the request.
 	}
 

--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -74,6 +74,9 @@ func validateRequest(r *http.Request, router routers.Router, options *Options) (
 	// Find route
 	route, pathParams, err := router.FindRoute(r)
 	if err != nil {
+		if errors.Is(err, routers.ErrMethodNotAllowed) {
+			return http.StatusMethodNotAllowed, err
+		}
 		return http.StatusNotFound, err // We failed to find a matching route for the request.
 	}
 

--- a/oapi_validate_example_test.go
+++ b/oapi_validate_example_test.go
@@ -164,6 +164,27 @@ components:
 	fmt.Println()
 
 	// ================================================================================
+	fmt.Println("# A request with an invalid HTTP method, to a valid path, is rejected with an HTTP 405 Method Not Allowed")
+	body = map[string]string{
+		"invalid": "not expected",
+	}
+
+	data, err = json.Marshal(body)
+	must(err)
+
+	req, err = http.NewRequest(http.MethodPatch, "/resource", bytes.NewReader(data))
+	must(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	rr = httptest.NewRecorder()
+
+	server.ServeHTTP(rr, req)
+
+	fmt.Printf("Received an HTTP %d response. Expected HTTP 405\n", rr.Code)
+	logResponseBody(rr)
+	fmt.Println()
+
+	// ================================================================================
 	fmt.Println("# A request that is well-formed is passed through to the Handler")
 	body = map[string]string{
 		"name": "Jamie",
@@ -206,6 +227,10 @@ components:
 	// # A request that is malformed is rejected with HTTP 400 Bad Request (because an invalid property is sent, and we have `additionalProperties: false`)
 	// Received an HTTP 400 response. Expected HTTP 400
 	// Response body: request body has an error: doesn't match schema: property "invalid" is unsupported
+	//
+	// # A request with an invalid HTTP method, to a valid path, is rejected with an HTTP 405 Method Not Allowed
+	// Received an HTTP 405 response. Expected HTTP 405
+	// Response body: method not allowed
 	//
 	// # A request that is well-formed is passed through to the Handler
 	// POST /resource was called


### PR DESCRIPTION
## Overview

I fixed `OapiRequestValidator` to return `http.StatusMethodNotAllowed` instead of `http.StatusNotFound` when the request method does not match the routing definition.

## Details

When the request method does not match the routing definition, the router returns `ErrMethodNotAllowed`.
However, in the current implementation of `OapiRequestValidator`, it returns `http.StatusNotFound` regardless of the error returned by the router.
This caused an unexpected response where the status would be `status = 404, body = method not allowed` when the request method didn’t match.

In this PR, I fixed `validateRequest()` to use `errors.Is()` to check the error and return the appropriate status code based on its value.

Additionally, I added test code for cases where the request method doesn't match.
This issue only occurs when combined with net/http, as both chi and gorilla probably handle this internally and return `http.StatusMethodNotAllowed` without needing fixes.