### PR TITLE
chore: remove references to Swagger

### DIFF
--- a/internal/test/chi/oapi_validate_test.go
+++ b/internal/test/chi/oapi_validate_test.go
@@ -44,21 +44,21 @@ func doPost(t *testing.T, mux http.Handler, rawURL string, jsonBody interface{})
 }
 
 func TestOapiRequestValidator(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := chi.NewRouter()
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidator(swagger))
+	r.Use(middleware.OapiRequestValidator(spec))
 
 	// basic cases
 	testRequestValidatorBasicFunctions(t, r)
 }
 
 func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := chi.NewRouter()
 
@@ -74,7 +74,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	}
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidatorWithOptions(swagger, &options))
+	r.Use(middleware.OapiRequestValidatorWithOptions(spec, &options))
 
 	called := false
 
@@ -156,8 +156,8 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 }
 
 func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := chi.NewRouter()
 
@@ -176,7 +176,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	}
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidatorWithOptions(swagger, &options))
+	r.Use(middleware.OapiRequestValidatorWithOptions(spec, &options))
 
 	called := false
 
@@ -258,8 +258,8 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 }
 
 func TestOapiRequestValidatorWithOptions(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := chi.NewRouter()
 
@@ -283,7 +283,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	}
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidatorWithOptions(swagger, &options))
+	r.Use(middleware.OapiRequestValidatorWithOptions(spec, &options))
 
 	// basic cases
 	testRequestValidatorBasicFunctions(t, r)

--- a/internal/test/gorilla/oapi_validate_test.go
+++ b/internal/test/gorilla/oapi_validate_test.go
@@ -44,21 +44,21 @@ func doPost(t *testing.T, mux http.Handler, rawURL string, jsonBody interface{})
 }
 
 func TestOapiRequestValidator(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := mux.NewRouter()
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidator(swagger))
+	r.Use(middleware.OapiRequestValidator(spec))
 
 	// basic cases
 	testRequestValidatorBasicFunctions(t, r)
 }
 
 func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := mux.NewRouter()
 
@@ -74,7 +74,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	}
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidatorWithOptions(swagger, &options))
+	r.Use(middleware.OapiRequestValidatorWithOptions(spec, &options))
 
 	called := false
 
@@ -156,8 +156,8 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 }
 
 func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := mux.NewRouter()
 
@@ -176,7 +176,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	}
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidatorWithOptions(swagger, &options))
+	r.Use(middleware.OapiRequestValidatorWithOptions(spec, &options))
 
 	called := false
 
@@ -258,8 +258,8 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 }
 
 func TestOapiRequestValidatorWithOptions(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := mux.NewRouter()
 
@@ -283,7 +283,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	}
 
 	// register middleware
-	r.Use(middleware.OapiRequestValidatorWithOptions(swagger, &options))
+	r.Use(middleware.OapiRequestValidatorWithOptions(spec, &options))
 
 	// basic cases
 	testRequestValidatorBasicFunctions(t, r)

--- a/internal/test/nethttp/oapi_validate_test.go
+++ b/internal/test/nethttp/oapi_validate_test.go
@@ -48,21 +48,21 @@ func use(r *http.ServeMux, mw func(next http.Handler) http.Handler) http.Handler
 }
 
 func TestOapiRequestValidator(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := http.NewServeMux()
 
 	// create middleware
-	mw := middleware.OapiRequestValidator(swagger)
+	mw := middleware.OapiRequestValidator(spec)
 
 	// basic cases
 	testRequestValidatorBasicFunctions(t, r, mw)
 }
 
 func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
@@ -91,7 +91,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	})
 
 	// register middleware
-	mw := middleware.OapiRequestValidatorWithOptions(swagger, &options)
+	mw := middleware.OapiRequestValidatorWithOptions(spec, &options)
 	server := mw(r)
 
 	// Let's send a good request, it should pass
@@ -166,8 +166,8 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 }
 
 func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := http.NewServeMux()
 
@@ -199,7 +199,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	})
 
 	// register middleware
-	server := use(r, middleware.OapiRequestValidatorWithOptions(swagger, &options))
+	server := use(r, middleware.OapiRequestValidatorWithOptions(spec, &options))
 
 	// Let's send a good request, it should pass
 	{
@@ -273,8 +273,8 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 }
 
 func TestOapiRequestValidatorWithOptions(t *testing.T) {
-	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
-	require.NoError(t, err, "Error initializing swagger")
+	spec, err := openapi3.NewLoader().LoadFromData(testSchema)
+	require.NoError(t, err, "Error initializing OpenAPI spec")
 
 	r := http.NewServeMux()
 
@@ -298,7 +298,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	}
 
 	// register middleware
-	mw := middleware.OapiRequestValidatorWithOptions(swagger, &options)
+	mw := middleware.OapiRequestValidatorWithOptions(spec, &options)
 	server := use(r, mw)
 
 	// basic cases

--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -31,18 +31,18 @@ type Options struct {
 	SilenceServersWarning bool
 }
 
-// OapiRequestValidator Creates middleware to validate request by swagger spec.
-func OapiRequestValidator(swagger *openapi3.T) func(next http.Handler) http.Handler {
-	return OapiRequestValidatorWithOptions(swagger, nil)
+// OapiRequestValidator Creates middleware to validate request by OpenAPI spec.
+func OapiRequestValidator(spec *openapi3.T) func(next http.Handler) http.Handler {
+	return OapiRequestValidatorWithOptions(spec, nil)
 }
 
-// OapiRequestValidatorWithOptions Creates middleware to validate request by swagger spec.
-func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func(next http.Handler) http.Handler {
-	if swagger.Servers != nil && (options == nil || !options.SilenceServersWarning) {
+// OapiRequestValidatorWithOptions Creates middleware to validate request by OpenAPI spec.
+func OapiRequestValidatorWithOptions(spec *openapi3.T, options *Options) func(next http.Handler) http.Handler {
+	if spec.Servers != nil && (options == nil || !options.SilenceServersWarning) {
 		log.Println("WARN: OapiRequestValidatorWithOptions called with an OpenAPI spec that has `Servers` set. This may lead to an HTTP 400 with `no matching operation was found` when sending a valid request, as the validator performs `Host` header validation. If you're expecting `Host` header validation, you can silence this warning by setting `Options.SilenceServersWarning = true`. See https://github.com/deepmap/oapi-codegen/issues/882 for more information.")
 	}
 
-	router, err := gorillamux.NewRouter(swagger)
+	router, err := gorillamux.NewRouter(spec)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
As it's been OpenAPI for a while.

Related: https://togithub.com/oapi-codegen/oapi-codegen/issues/672
