### PR TITLE
refactor: migrate `error` to a method parameter, not part of `ErrorHandlerOpts`

### DIFF
--- a/oapi_validate_example_test.go
+++ b/oapi_validate_example_test.go
@@ -469,9 +469,7 @@ components:
 		return fmt.Errorf("this check always fails - don't let anyone in!")
 	}
 
-	errorHandlerFunc := func(ctx context.Context, w http.ResponseWriter, r *http.Request, opts middleware.ErrorHandlerOpts) {
-		err := opts.Error
-
+	errorHandlerFunc := func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request, opts middleware.ErrorHandlerOpts) {
 		if opts.MatchedRoute == nil {
 			fmt.Printf("ErrorHandlerWithOpts: An HTTP %d was returned by the middleware with error message: %s\n", opts.StatusCode, err.Error())
 
@@ -716,9 +714,7 @@ paths:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
 
-	errorHandlerFunc := func(ctx context.Context, w http.ResponseWriter, r *http.Request, opts middleware.ErrorHandlerOpts) {
-		err := opts.Error
-
+	errorHandlerFunc := func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request, opts middleware.ErrorHandlerOpts) {
 		if opts.MatchedRoute == nil {
 			fmt.Printf("ErrorHandlerWithOpts: An HTTP %d was returned by the middleware with error message: %s\n", opts.StatusCode, err.Error())
 


### PR DESCRIPTION
While writing the documentation for this, it didn't feel quite right to
note that the `error` wasn't part of the method signature, despite it
being very important for the actual handling of errors.