### PR TITLE
Fix release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,0 @@
-_extends: .github


### PR DESCRIPTION
v7 of release drafter looks into the repo org by default, and the syntax of the v6 config to do so doesn't work anymore and causes errors.

By removing the _extends statement, we get the old behavior in V7.